### PR TITLE
Slight improvements to exitWithError()

### DIFF
--- a/includes/Wpup/UpdateServer.php
+++ b/includes/Wpup/UpdateServer.php
@@ -289,8 +289,7 @@ class Wpup_UpdateServer {
 		
 		if ( !isset($_SERVER['SERVER_PROTOCOL']) || $_SERVER['SERVER_PROTOCOL'] === '' ) {
 			$protocol = 'HTTP/1.1';
-		}
-		else {
+		} else {
 			$protocol = $_SERVER['SERVER_PROTOCOL'];
 		}
 


### PR DESCRIPTION
- Allow empty error message - will default to the title
- Respect the protocol of the server
