### PR TITLE
Make one error message slightly more useful

### DIFF
--- a/includes/Wpup/Package.php
+++ b/includes/Wpup/Package.php
@@ -79,7 +79,7 @@ class Wpup_Package {
 		if ( !isset($metadata) || !is_array($metadata) ) {
 			$metadata = self::extractMetadata($filename);
 			if ( $metadata === null ) {
-				throw new Wpup_InvalidPackageException('The specified file does not contain a valid WordPress plugin or theme.');
+				throw new Wpup_InvalidPackageException( sprintf('The specified file %s does not contain a valid WordPress plugin or theme.', $filename));
 			}
 			$metadata['last_updated'] = gmdate('Y-m-d H:i:s', $modified);
 		}


### PR DESCRIPTION
The exception did not include the filename making it difficult to identify which package the error referred to.
