### PR TITLE
Implement class autoloading

### DIFF
--- a/loader.php
+++ b/loader.php
@@ -1,11 +1,33 @@
 <?php
-require_once __DIR__ . '/includes/Wpup/Package.php';
-require_once __DIR__ . '/includes/Wpup/InvalidPackageException.php';
-require_once __DIR__ . '/includes/Wpup/Request.php';
-require_once __DIR__ . '/includes/Wpup/Cache.php';
-require_once __DIR__ . '/includes/Wpup/FileCache.php';
-require_once __DIR__ . '/includes/Wpup/UpdateServer.php';
 
-if ( !class_exists('WshWordPressPackageParser') ) {
-	require_once __DIR__ . '/includes/extension-meta/extension-meta.php';
+/**
+ * Auto load class files
+ *
+ * @param   string  $class  Class name
+ * @return  void
+ */
+function wpup_auto_load($class) {
+	static $classes = null;
+
+	if ($classes === null) {
+		$classes = array(
+			'wpup_package'  => __DIR__ . '/includes/Wpup/Package.php',
+			'wpup_invalidpackageexception' => __DIR__ . '/includes/Wpup/InvalidPackageException.php',
+			'wpup_request' => __DIR__ . '/includes/Wpup/Request.php',
+			'wpup_cache' => __DIR__ . '/includes/Wpup/Cache.php',
+			'wpup_filecache' => __DIR__ . '/includes/Wpup/FileCache.php',
+			'wpup_updateserver' => __DIR__ . '/includes/Wpup/UpdateServer.php',
+		);
+
+		if ( !class_exists('WshWordPressPackageParser') ) {
+			$classes['wshwordpresspackageparser'] = __DIR__ . '/includes/extension-meta/extension-meta.php';
+		}
+	}
+
+	$cn = strtolower($class);
+
+	if ( isset($classes[ $cn ])) {
+		require_once($classes[ $cn ]);
+	}
 }
+spl_autoload_register('wpup_auto_load');


### PR DESCRIPTION
As the Wp-update-server requires PHP5.3 anyway, we might as well. SPL can't be disabled (in PHP5.3+), so will be available.
