### PR TITLE
Use native json pretty printing if available

### DIFF
--- a/includes/Wpup/UpdateServer.php
+++ b/includes/Wpup/UpdateServer.php
@@ -257,7 +257,7 @@ class Wpup_UpdateServer {
 	protected function outputAsJson($response) {
 		header('Content-Type: application/json');
 		$output = '';
-		if ( defined('JSON_PRETTY_PRINT') && JSON_PRETTY_PRINT ) {
+		if ( defined('JSON_PRETTY_PRINT') ) {
 			$output = json_encode($response, JSON_PRETTY_PRINT);
 		} elseif ( function_exists('wsh_pretty_json') ) {
 			$output = wsh_pretty_json(json_encode($response));


### PR DESCRIPTION
`JSON_PRETTY_PRINT` constant has been available since PHP5.4, so let's use it.
