### PR TITLE
Bug fix for metadata caching

### DIFF
--- a/includes/Wpup/Package.php
+++ b/includes/Wpup/Package.php
@@ -89,12 +89,13 @@ class Wpup_Package {
 				throw new Wpup_InvalidPackageException( sprintf('The specified file %s does not contain a valid WordPress plugin or theme.', $filename));
 			}
 			$metadata['last_updated'] = gmdate('Y-m-d H:i:s', $modified);
+			
+			//Update cache.
+			if ( isset($cache) ) {
+				$cache->set($cacheKey, $metadata, self::$cacheTime);
+			}
 		}
 
-		//Update cache.
-		if ( isset($cache) ) {
-			$cache->set($cacheKey, $metadata, self::$cacheTime);
-		}
 		if ( $slug === null ) {
 			$slug = $metadata['slug'];
 		}


### PR DESCRIPTION
Sending this in as a separate PR as I want to keep it out of the discussion on PR #21.

I was wondering why the metadata cache files kept being updated (new save date/time) even when the cache shouldn't have expired yet.

That's when I found this. Basically any non-expired cache was being retrieved and then resaved with a new expiration timestamp, which - depending on the cache time chosen and how often the metadata gets retrieved - would mean that the cache effectively would never get refreshed.