### PR TITLE
Escape log data before writing to file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,8 @@
 	],
 	"require": {
 		"php": ">=5.3.0"
+	},
+	"suggest": {
+		"ext-mbstring": "Used for escaping log values in a utf8 compatible manner. If the extension isn't installed logged values are handled as single-byte character strings."
 	}
 }


### PR DESCRIPTION
This escapes special chars in logged data to avoid breaking the log file with something like `?installed_version=%0D%0A%09+` in url. The purpose of the added method `escapeLogInfo()` is similar to `mysql[_real]_escape_string()`, `htmlspecialchars()`, `escapeshellarg()`, etc.