### PR TITLE
Allow cache time to be overridden in a subclass

### DIFF
--- a/includes/Wpup/ZipMetadataParser.php
+++ b/includes/Wpup/ZipMetadataParser.php
@@ -105,7 +105,7 @@ class Wpup_ZipMetadataParser {
 
 			//Update cache.
 			if ( isset($this->cache) ){
-				$this->cache->set($cacheKey, $this->metadata, self::$cacheTime);
+				$this->cache->set($cacheKey, $this->metadata, static::$cacheTime);
 			}
 		}
 	}


### PR DESCRIPTION
Replace "self::" with "static::" to be able to override the cache time value in a subclass.

Reference: https://www.php.net/manual/en/language.oop5.late-static-bindings.php