### PR TITLE
Feature-detect GLOB_BRACE for musl-libc PHP builds (Alpine, static FrankenPHP)

### DIFF
--- a/includes/Wpup/UpdateServer.php
+++ b/includes/Wpup/UpdateServer.php
@@ -385,13 +385,28 @@ class Wpup_UpdateServer {
 	) {
 		$pattern = $this->assetDirectories[$assetType] . '/' . $package->slug . $suffix;
 
+		//GLOB_BRACE is not defined on every libc (e.g. musl, used by Alpine/static
+		//FrankenPHP builds). When it's missing, fall back to one glob() call per
+		//extension and merge the results. Behaviour is identical otherwise.
 		if ( is_array($extensions) ) {
-			$extensionPattern = '{' . implode(',', $extensions) . '}';
+			if ( defined('GLOB_BRACE') ) {
+				$assets = glob(
+					$pattern . '.{' . implode(',', $extensions) . '}',
+					GLOB_BRACE | GLOB_NOESCAPE
+				);
+			} else {
+				$assets = array();
+				foreach ($extensions as $extension) {
+					$matches = glob($pattern . '.' . $extension, GLOB_NOESCAPE);
+					if ( !empty($matches) ) {
+						$assets = array_merge($assets, $matches);
+					}
+				}
+			}
 		} else {
-			$extensionPattern = $extensions;
+			$assets = glob($pattern . '.' . $extensions, GLOB_NOESCAPE);
 		}
 
-		$assets = glob($pattern . '.' . $extensionPattern, GLOB_BRACE | GLOB_NOESCAPE);
 		if ( !empty($assets) ) {
 			$firstFile = basename(reset($assets));
 			return $this->generateAssetUrl($assetType, $firstFile);


### PR DESCRIPTION
## Summary

`Wpup_UpdateServer::findFirstAsset()` references `GLOB_BRACE` unconditionally:

https://github.com/YahnisElsts/wp-update-server/blob/master/includes/Wpup/UpdateServer.php#L394

`GLOB_BRACE` is **not defined** on PHP builds linked against **musl libc** — for example Alpine container images and the official static **FrankenPHP** binary releases (see PHP manual note: "GLOB_BRACE is not available on some non-GNU systems, like Solaris or Alpine Linux").

In **PHP 8** referencing an undefined constant is a **fatal `Error`** (not the PHP 7 warning), so every call to `findFirstAsset()` crashes the update API response when it tries to resolve a plugin banner or icon:

```
PHP Fatal error:  Uncaught Error: Undefined constant "GLOB_BRACE"
  in .../includes/Wpup/UpdateServer.php:394
```

## Change

Switch the array-of-extensions branch to runtime feature detection:

- When `GLOB_BRACE` is defined, behaviour is identical to before (single `glob()` with the brace pattern).
- When it is missing, fall back to one `glob()` call per extension and merge results.
- The string-extension branch no longer passes `GLOB_BRACE` since it was meaningless without braces.

## Reproduce

```bash
# On any musl-libc PHP build (Alpine, static FrankenPHP):
php -r 'var_dump(defined("GLOB_BRACE"));'   # => bool(false)
# Hit any update API endpoint that resolves a banner/icon — fatal in error log.
```

## Verification

- `php -l` clean.
- Smoke test exercising all branches (array+brace, array+fallback, string-extension, no-match) returns identical results under glibc system PHP and musl FrankenPHP.
- Tested on a live install (FrankenPHP v1.4.4, PHP 8.4.5, static musl build): update API requests now respond normally; previously each one fatal-ed.

## Notes

No behavioural change on glibc systems. No new dependencies. No public API changes.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 14h 36m and 15,815 tokens on this as a headless worker.
